### PR TITLE
OTTR contributor count

### DIFF
--- a/03_itn-eval-metrics_plots_other.Rmd
+++ b/03_itn-eval-metrics_plots_other.Rmd
@@ -67,8 +67,8 @@ number_contributors <-
     purrr:::map(results, ~.x$login)
   })
 
-# number of "OTTR users"
-length(unique(unlist(number_contributors)))
+# number of "OTTR users" but "actions user" and "jhudsl-robot" don't count so subtract 2
+length(unique(unlist(number_contributors))) - 2
 ```
 
 ## OPEN attendance

--- a/03_itn-eval-metrics_plots_other.Rmd
+++ b/03_itn-eval-metrics_plots_other.Rmd
@@ -58,6 +58,18 @@ ottr_df %>%
   dplyr::count()
 ```
 
+```{r}
+ottr_contributors <- ottr_df %>% dplyr::select("organization", "repo")
+
+number_contributors <- 
+  purrr::pmap(ottr_contributors, function(organization, repo) {
+    results <- gh::gh("GET https://api.github.com/repos/{owner}/{repo}/contributors", owner = organization, repo = repo, .limit = Inf)
+    purrr:::map(results, ~.x$login)
+  })
+
+# number of "OTTR users"
+length(unique(unlist(number_contributors)))
+```
 
 ## OPEN attendance
 


### PR DESCRIPTION
We needed an estimate for the number of "OTTR users" we've had for a grant application.

So to do this I pulled up the number of contributors for every OTTR repo we have on file using the GitHub API.

53 "OTTR users" is what we've had but we have to subtract 2 from that because "actions user" and "jhudsl-robot" don't count. 

So 51 OTTR users. 

#11 Was the predecessor to this but it had some additional things in there that shouldn't have been in there so I made a new branch. 